### PR TITLE
Added better Telegram string regex for proxy services and fixes.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ nltk
 numpy
 rake-nltk
 web3
-web3bs4
+bs4

--- a/restalker/restalker.py
+++ b/restalker/restalker.py
@@ -317,7 +317,10 @@ bitname_domain_regex = r"(?:[a-zA-Z0-9]+\.)+bit"
 
 tw_account_regex = r"[^a-zA-Z0-9]@([a-zA-Z0-9_]{3,15})"
 
-telegram_url_regex = r"((?:https?\:\/\/)?(?:t\.me|telegram\.me)(?:\/[a-zA-Z0-9_-]+)+)"
+telegram_url_regex = re.compile(
+    r"((?:https?:\/\/)?(?:t\.me|telegram\.me|teleg\.one|tgclick\.com)(?:\/[a-zA-Z0-9_-]+)+)|"
+    r"((?:tg:\/\/)(?:[a-zA-Z0-9_-]+\?[a-zA-Z0-9_-]+=[a-zA-Z0-9_-]+)+)"
+)
 
 whatsapp_url_regex = r"((?:https?\:\/\/)?chat\.whatsapp\.com(?:\/[a-zA-Z0-9_-]+)+)"
 
@@ -471,7 +474,8 @@ def extract_elements(x):
         result = list()
         for piece in x:
             for element in extract_elements(piece):
-                result.append(element)
+                if element != "":
+                    result.append(element)
         return set(result)
     else:
         return [x]
@@ -820,6 +824,7 @@ class reStalker:
 
         if self.telegram:
             telegram_links = re.findall(telegram_url_regex, body)
+            telegram_links = extract_elements(telegram_links)
             for link in telegram_links:
                 try:
                     link_item = UUF(link).full_url
@@ -883,10 +888,10 @@ class reStalker:
         chunk_size = buff_size // 2
 
         # print("Chunks", len(body)//chunk_size)
-
+        
         while i * chunk_size <= len(body):
 
-            chunk = body[i * chunk_size : (i + 2) * chunk_size]
+            chunk = body[i * chunk_size : (i + 1) * chunk_size]
             chunk_analysis = self._analyze_chunk(chunk, origin=origin)
 
             for result in chunk_analysis:

--- a/test.py
+++ b/test.py
@@ -3256,13 +3256,38 @@ Man is the master of everything and decides everything.
   gtag('config', 'UA-12345678-9');
 </script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-9876543210"></script>
+
+https://t.me/resource
+https://telegram.me/resource
+https://teleg.one/resource
+https://tgclick.com/resource
+
+t.me/resource
+telegram.me/resource
+teleg.one/resource
+tgclick.com/resource
+
+t.me/secret_resource
+telegram.me/secret_resource
+teleg.one/secret_resource
+tgclick.com/secret_resource
+
+t.me/secret-resource
+telegram.me/secret-resource
+teleg.one/secret-resource
+tgclick.com/secret-resource
+
+tg://resource?id=007
+tg://resource?id=blablabla
 """
 
 nltk.download('punkt_tab')
 nltk.download('stopwords')
 
-s = restalker.reStalker(all=True)
+s = restalker.reStalker(telegram=True)
 # s = restalker.reStalker(tor=True)
-
-for p in s.parse(target):
+ 
+result = list(s.parse(target))
+print(f"Len: {len(result)}")
+for p in result:
     print(p)


### PR DESCRIPTION
- Added domains on Telegram string regex for proxy services.
- Added some strings for testing telegram.
- Fixed requirements.txt typo on bs4 module.
- Filter out empty strings on extract_elements.
- Changed chunk procesing to not overlap and prevent duplicated results. (This could give a false negative if a string is separated in 2 chunks [restalker/restalker.py Line 889/884]).