### PR TITLE
Fixed GA Tracking codes detection

### DIFF
--- a/restalker/restalker.py
+++ b/restalker/restalker.py
@@ -276,7 +276,7 @@ class GA_Tracking_Code(Item):
     @staticmethod
     def isvalid(code: str) -> bool:
         # Validate that the code is not part of a larger string
-        return bool(re.match(r'^(?:UA-\d{4,10}-\d|G-[A-Za-z0-9]{10})$', code))
+        return bool(re.fullmatch(r'(?:UA-\d{4,10}-\d|G-[A-Za-z0-9]{10})', code))
 
 
 number_regex = r"[0-9]+"

--- a/restalker/restalker.py
+++ b/restalker/restalker.py
@@ -273,7 +273,10 @@ class PGP(Item):
 
 
 class GA_Tracking_Code(Item):
-    pass
+    @staticmethod
+    def isvalid(code: str) -> bool:
+        # Validate that the code is not part of a larger string
+        return bool(re.match(r'^(?:UA-\d{4,10}-\d|G-[A-Za-z0-9]{10})$', code))
 
 
 number_regex = r"[0-9]+"
@@ -376,7 +379,7 @@ pgp_footer = r'-----END PGP (?:PUBLIC|PRIVATE) KEY BLOCK-----'
 pgp_key = r"(%s[\s\S]{175,5000}%s)" % (pgp_header, pgp_footer)
 
 
-ga_tracking_code_regex = r"(UA-\d{4,10}-\d|G-\w{10})"
+ga_tracking_code_regex = r"\b(UA-\d{4,10}-\d|G-[A-Za-z0-9]{10})\b"
 
 """
 Freenet URL spec:
@@ -906,7 +909,8 @@ class reStalker:
         if self.gatc:
             gatc = re.findall(ga_tracking_code_regex, body)
             for g in gatc:
-                yield GA_Tracking_Code(value=g)
+                if GA_Tracking_Code.isvalid(g):
+                    yield GA_Tracking_Code(value=g)
 
     def parse(self, body, origin=None, buff_size=20480):
 

--- a/unit_test.py
+++ b/unit_test.py
@@ -336,7 +336,7 @@ def test_url_detection(sample_url_data):
     assert len(ipfs) > 0
 
 def test_analytics_code_detection():
-    data = "Google Analytics: UA-12345678-9 and G-ABCDEFGHIJ"
+    data = "Google Analytics: UA-12345678-9 and G-ABCDEFGHIJ www.website.com/UXF8qo74PzHxW3oSkcJt2DG-nqZGb38pCiYTIHyDa0[/HIDEREACT]"
     stalker = reStalker(gatc=True)
     results = list(stalker.parse(data))
     codes = [r for r in results if isinstance(r, GA_Tracking_Code)]


### PR DESCRIPTION
Based on Issue #12

1. Added word boundaries (`\b`) to the regex pattern to ensure the GA tracking code is not part of a larger string.
2. Made the pattern more specific by using `[A-Za-z0-9]` instead of `\w` for the G- format.
3. Added a static validation method to the GA_Tracking_Code class that does strict validation.
4. Modified the parsing code to only yield GA tracking codes that pass the validation.
5. Validation on test_analytics_code_detection test passed.
